### PR TITLE
Avoid error where sending without any clients to send to would fail

### DIFF
--- a/untangled-2018/lib/network.py
+++ b/untangled-2018/lib/network.py
@@ -146,6 +146,10 @@ class Network:
 
     def push_game(self, game, initial=False):
         """Tell others how we've changed the game state."""
+        if len(self.node.peers_by_group(self.get_our_group())) == 0:
+            # Nobody else to talk to
+            return
+
         entities = {
             'components': {}
         }


### PR DESCRIPTION
Gets rid of the annoying `Group ... was not found` message.

This happened when we Pyre `shout`'d when no other nodes were connected to the group; now we check.